### PR TITLE
colorlog 6.10.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,26 @@
-{% set version = "4.8.0" %}
+{% set name = "colorlog" %}
+{% set version = "6.10.1" %}
 
 package:
-  name: colorlog
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: colorlog-{{ version }}.tar.gz
-  url: https://pypi.org/packages/source/c/colorlog/colorlog-{{ version }}.tar.gz
-  sha256: 59b53160c60902c405cdec28d38356e09d40686659048893e026ecbd589516b1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321
 
 build:
-  number: 2
-  script: {{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt
+  number: 0
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
+    - pip
     - python
     - setuptools >=38.6.0
+    - wheel
     - colorama  # [win]
-
   run:
     - python
     - colorama  # [win]
@@ -33,9 +35,9 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Log formatting with colors!
+  description: Add colours to the output of Python's logging module.
   dev_url: https://github.com/borntyping/python-colorlog
   doc_url: https://github.com/borntyping/python-colorlog
-  description: Add colours to the output of Python's logging module.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
colorlog 6.10.1 

**Destination channel:** Defaults

### Links

- [PKG-10675]
- dev_url:        https://github.com/borntyping/python-colorlog/tree/v6.10.1
- conda_forge:    https://github.com/conda-forge/colorlog-feedstock
- pypi:           https://pypi.org/project/colorlog/6.10.1
- pypi inspector: https://inspector.pypi.io/project/colorlog/6.10.1

### Explanation of changes:

- new version number


[PKG-10675]: https://anaconda.atlassian.net/browse/PKG-10675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ